### PR TITLE
Fix product grids with variable image heights

### DIFF
--- a/assets/styles.scss.liquid
+++ b/assets/styles.scss.liquid
@@ -1496,6 +1496,7 @@ a.tag {
   float: left;
   width: 23%;
   margin: 0 1% 20px;
+  height: 23em;
   padding: 1.5% 1.5% 0;
   border: 1px solid #eee;
   text-align: center;
@@ -1504,10 +1505,16 @@ a.tag {
     width: 48%;
   }
 
+  a.grid__image {
+    display: block;
+    height: 16em;
+  }
+
   img {
     max-width: 100%;
-    max-height: 233px;
+    max-height: 15em;
   }
+
   .product-grid-title {
     line-height: 20px;
     margin-bottom: 0;

--- a/assets/styles.scss.liquid
+++ b/assets/styles.scss.liquid
@@ -1505,8 +1505,8 @@ a.tag {
   }
 
   img {
-    width: 100%;
-    height: auto;
+    max-width: 100%;
+    max-height: 233px;
   }
   .product-grid-title {
     line-height: 20px;

--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -56,7 +56,7 @@
 
   {% endcomment %}
   <a href="{{ product.url | within: collection }}" class="grid__image">
-    <img src="{{ product.featured_image.src | img_url: 'grande' }}" alt="{{ product.featured_image.alt | escape }}">
+    <img src="{{ product.featured_image.src | img_url: '600x600' }}" alt="{{ product.featured_image.alt | escape }}">
   </a>
 
   {% assign product_vendor_handle = product.vendor | handle %}


### PR DESCRIPTION
- [x] Not using Shopify named image sizes (deprecated)
- [x] Fixed with `em` sizing, though wondering if `flex-box` should be used